### PR TITLE
Add timestamps to all log output

### DIFF
--- a/pkg/log/log.go
+++ b/pkg/log/log.go
@@ -2,6 +2,7 @@ package log
 
 import (
 	"fmt"
+	"time"
 )
 
 const (
@@ -13,27 +14,31 @@ const (
 	ColorWhite  = "\033[37m"
 )
 
+func timestamp() string {
+	return time.Now().Format("2006-01-02 15:04:05.000")
+}
+
 func Info(msg string, args ...interface{}) {
 	formatted := fmt.Sprintf(msg, args...)
-	fmt.Println(ColorWhite, formatted, ColorReset)
+	fmt.Printf("[%s] %s%s%s\n", timestamp(), ColorWhite, formatted, ColorReset)
 }
 
 func Wait(msg string, args ...interface{}) {
 	formatted := fmt.Sprintf(msg, args...) + "..."
-	fmt.Println(ColorBlue, formatted, ColorReset)
+	fmt.Printf("[%s] %s%s%s\n", timestamp(), ColorBlue, formatted, ColorReset)
 }
 
 func Good(msg string, args ...interface{}) {
 	formatted := fmt.Sprintf(msg, args...)
-	fmt.Println(ColorGreen, formatted, ColorReset)
+	fmt.Printf("[%s] %s%s%s\n", timestamp(), ColorGreen, formatted, ColorReset)
 }
 
 func Warn(msg string, args ...interface{}) {
 	formatted := fmt.Sprintf(msg, args...)
-	fmt.Println(ColorYellow, formatted, ColorReset)
+	fmt.Printf("[%s] %s%s%s\n", timestamp(), ColorYellow, formatted, ColorReset)
 }
 
 func Error(msg string, args ...interface{}) {
 	formatted := fmt.Sprintf(msg, args...)
-	fmt.Println(ColorRed, formatted, ColorReset)
+	fmt.Printf("[%s] %s%s%s\n", timestamp(), ColorRed, formatted, ColorReset)
 }


### PR DESCRIPTION
## Summary
- Added timestamps to all log output messages for better debugging and monitoring
- Timestamps are formatted as `[YYYY-MM-DD HH:MM:SS.mmm]` and appear before each log message
- Affects all logging functions: Info, Wait, Good, Warn, Error

## Test plan
- [x] Build the project successfully with `go build`
- [x] Test timestamp output with `./cloudexec version`
- [x] Verify timestamps appear in different log levels (Info, Good, Error)
- [x] Confirm colors still work correctly with timestamps

🤖 Generated with [Claude Code](https://claude.ai/code)